### PR TITLE
Return the original input when no rules exist or match

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Metrics/MetricNameService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Metrics/MetricNameService.cs
@@ -123,7 +123,7 @@ namespace NewRelic.Agent.Core.Metrics
 
         private static bool TryRenameUsingRegexRules(string input, IEnumerable<RegexRule> rules, out string result)
         {
-            result = null;
+            result = input;
             bool success = true;
 
             foreach (var rule in rules.OrderBy(rule => rule.EvaluationOrder))


### PR DESCRIPTION
This fixes unit test failures I was having, by making this method output the original input string if there are no rules to match or if no rules match.