### PR TITLE
Apply rules to result instead of input

### DIFF
--- a/src/Agent/NewRelic/Agent/Core/Metrics/MetricNameService.cs
+++ b/src/Agent/NewRelic/Agent/Core/Metrics/MetricNameService.cs
@@ -128,7 +128,7 @@ namespace NewRelic.Agent.Core.Metrics
 
             foreach (var rule in rules.OrderBy(rule => rule.EvaluationOrder))
             {
-                var ruleResult = rule.ApplyTo(input);
+                var ruleResult = rule.ApplyTo(result);
                 if (!ruleResult.IsMatch)
                 {
                     continue;


### PR DESCRIPTION
One more change that fixes some additional unit test failures, which I'm not sure how I missed yesterday. :-/

